### PR TITLE
Fixed documentation for helper methods

### DIFF
--- a/docs/graph_nets.md
+++ b/docs/graph_nets.md
@@ -3940,11 +3940,11 @@ Returns a data dict of Numpy data from a networkx graph.
 
 The networkx graph should be set up such that, for fixed shapes `node_shape`,
  `edge_shape` and `global_shape`:
-  - `graph_nx.nodes(data=True)[i][-1]["features"]` is, for any node index i, a
+  - `graph_nx.nodes(data=True)[i]["features"]` is, for any node index i, a
     tensor of shape `node_shape`, or `None`;
-  - `graph_nx.edges(data=True)[i][-1]["features"]` is, for any edge index i, a
+  - `graph_nx.edges(data=True)[i]["features"]` is, for any edge index i, a
     tensor of shape `edge_shape`, or `None`;
-  - `graph_nx.edges(data=True)[i][-1]["index"]`, if present, defines the order
+  - `graph_nx.edges(data=True)[i]["index"]`, if present, defines the order
     in which the edges will be sorted in the resulting `data_dict`;
   - `graph_nx.graph["features"] is a tensor of shape `global_shape`, or
     `None`.
@@ -3995,11 +3995,11 @@ Constructs an instance from an iterable of networkx graphs.
 
  The networkx graph should be set up such that, for fixed shapes `node_shape`,
  `edge_shape` and `global_shape`:
-  - `graph_nx.nodes(data=True)[i][-1]["features"]` is, for any node index i, a
+  - `graph_nx.nodes(data=True)[i]["features"]` is, for any node index i, a
     tensor of shape `node_shape`, or `None`;
-  - `graph_nx.edges(data=True)[i][-1]["features"]` is, for any edge index i, a
+  - `graph_nx.edges(data=True)[i]["features"]` is, for any edge index i, a
     tensor of shape `edge_shape`, or `None`;
-  - `graph_nx.edges(data=True)[i][-1]["index"]`, if present, defines the order
+  - `graph_nx.edges(data=True)[i]["index"]`, if present, defines the order
     in which the edges will be sorted in the resulting `data_dict`;
   - `graph_nx.graph["features"] is a tensor of shape `global_shape`, or
     `None`.
@@ -4312,11 +4312,11 @@ the shape of those graphs.
 
 The networkx graph should be set up such that, for fixed shapes `node_shape`,
  `edge_shape` and `global_shape`:
-  - `graph_nx.nodes(data=True)[i][-1]["features"]` is, for any node index i, a
+  - `graph_nx.nodes(data=True)[i]["features"]` is, for any node index i, a
     tensor of shape `node_shape`, or `None`;
-  - `graph_nx.edges(data=True)[i][-1]["features"]` is, for any edge index i, a
+  - `graph_nx.edges(data=True)[i]["features"]` is, for any edge index i, a
     tensor of shape `edge_shape`, or `None`;
-  - `graph_nx.edges(data=True)[i][-1]["index"]`, if present, defines the order
+  - `graph_nx.edges(data=True)[i]["index"]`, if present, defines the order
     in which the edges will be sorted in the resulting `data_dict`;
   - `graph_nx.graph["features"] is a tensor of shape `global_shape` or `None`.
 

--- a/graph_nets/utils_np.py
+++ b/graph_nets/utils_np.py
@@ -111,11 +111,11 @@ def networkx_to_data_dict(graph_nx,
 
   The networkx graph should be set up such that, for fixed shapes `node_shape`,
    `edge_shape` and `global_shape`:
-    - `graph_nx.nodes(data=True)[i][-1]["features"]` is, for any node index i, a
+    - `graph_nx.nodes(data=True)[i]["features"]` is, for any node index i, a
       tensor of shape `node_shape`, or `None`;
-    - `graph_nx.edges(data=True)[i][-1]["features"]` is, for any edge index i, a
+    - `graph_nx.edges(data=True)[i]["features"]` is, for any edge index i, a
       tensor of shape `edge_shape`, or `None`;
-    - `graph_nx.edges(data=True)[i][-1]["index"]`, if present, defines the order
+    - `graph_nx.edges(data=True)[i]["index"]`, if present, defines the order
       in which the edges will be sorted in the resulting `data_dict`;
     - `graph_nx.graph["features"] is a tensor of shape `global_shape`, or
       `None`.

--- a/graph_nets/utils_tf.py
+++ b/graph_nets/utils_tf.py
@@ -293,11 +293,11 @@ def placeholders_from_networkxs(graph_nxs,
 
   The networkx graph should be set up such that, for fixed shapes `node_shape`,
    `edge_shape` and `global_shape`:
-    - `graph_nx.nodes(data=True)[i][-1]["features"]` is, for any node index i, a
+    - `graph_nx.nodes(data=True)[i]["features"]` is, for any node index i, a
       tensor of shape `node_shape`, or `None`;
-    - `graph_nx.edges(data=True)[i][-1]["features"]` is, for any edge index i, a
+    - `graph_nx.edges(data=True)[i]["features"]` is, for any edge index i, a
       tensor of shape `edge_shape`, or `None`;
-    - `graph_nx.edges(data=True)[i][-1]["index"]`, if present, defines the order
+    - `graph_nx.edges(data=True)[i]["index"]`, if present, defines the order
       in which the edges will be sorted in the resulting `data_dict`;
     - `graph_nx.graph["features"] is a tensor of shape `global_shape` or `None`.
 


### PR DESCRIPTION
I removed a misleading index [-1] from the documentation in: `utils_np`, `utils_tf` and the doc itself.
The docstring now reflects what fields of the networkx graph are used to build the GraphsTuple structures.

I could also add a minimal example of creating a graph with networkx and converting it into a GraphsTuple, just tell me where to add it.