### PR TITLE
Speedup training on GPU (remove CPU bottleneck on broadcast phases)

### DIFF
--- a/graph_nets/utils_tf.py
+++ b/graph_nets/utils_tf.py
@@ -524,13 +524,15 @@ def repeat(tensor, repeats, axis=0, name="repeat"):
     The `tf.Tensor` with repeated values.
   """
   with tf.name_scope(name):
-    cumsum = tf.cumsum(repeats)
+    cumsum = tf.cumsum(tf.cast(repeats, tf.float64))
     range_ = tf.range(cumsum[-1])
 
     indicator_matrix = tf.cast(tf.expand_dims(range_, 1) >= cumsum, tf.int32)
     indices = tf.reduce_sum(indicator_matrix, reduction_indices=1)
 
     shifted_tensor = _axis_to_inside(tensor, axis)
+    if shifted_tensor.dtype == tf.int32:
+      shifted_tensor = tf.cast(shifted_tensor, tf.int64)
     repeated_shifted_tensor = tf.gather(shifted_tensor, indices)
     repeated_tensor = _inside_to_axis(repeated_shifted_tensor, axis)
 


### PR DESCRIPTION
Running against latest stable release of tensorflow (1.12) yields poor model performance for training/inference on GPU for `EncodeProcessDecode`-based models. It can be observed that CPU gets heavily used (and becomes the bottleneck) while GPU usage is spiky at best.

We observed that this happens because certain ops such as `tf.cumsum` and `tf.gather` were always being placed on the CPU even when allocated/running in a `with tf.device("/GPU:0")` block, which can be easily verified by running the session with `config=tf.ConfigProto(log_device_placement=True)`.

The cause of this behavior is that some of these ops don't have implementations for GPU for certain data types on the latest stable release (see tensorflow/tensorflow#5445, or this comment https://github.com/tensorflow/tensorflow/issues/13164#issuecomment-332076675 related to `gather_nd` which also applies to `cumsum` per current code in https://github.com/tensorflow/tensorflow/blob/73e3215c3a2edadbf9111cca44ab3d5ca146c327/tensorflow/core/kernels/scan_ops.cc#L149 ).

The consequence of this behavior is a significant slowdown on training because tensor data has to be copied from GPU memory, processed by CPU, and copied back to GPU, during the broadcast steps which cause serious bottlenecks in the computation graph.

This fix casts the data types into something that allows these ops to run in GPU. The cast overhead is insignificant compared with the performance gain. *We observed nearly 5x speedup in training* with a relatively simple EncodeProcessDecode model with 6 processing steps on GPU-enabled systems.

