### PR TITLE
fix installation of tensorflow_probability

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ pip install graph_nets tensorflow tensorflow_probability
 To install the Graph Nets library for GPU, run:
 
 ```shell
-$ pip install graph_nets tensorflow_gpu tensorflow_probability_gpu
+$ pip install graph_nets tensorflow_gpu tensorflow_probability
 ```
 
 ## Usage example


### PR DESCRIPTION
From tensorflow_probability v0.5.0, `pip install tensorflow_probability_gpu` does not work.
https://github.com/tensorflow/probability/releases/tag/v0.5.0

`tensorflow_probability_gpu` is consolidated to `tensorflow_probability` .

This PR fixes it.