### PR TITLE
Suggested number of training iterations

### DIFF
--- a/graph_nets/demos/physics.ipynb
+++ b/graph_nets/demos/physics.ipynb
@@ -538,7 +538,7 @@
         "num_processing_steps_ge = 1\n",
         "\n",
         "# Data / training parameters.\n",
-        "num_training_iterations = 100000\n",
+        "num_training_iterations = 20000\n",
         "batch_size_tr = 256\n",
         "batch_size_ge = 100\n",
         "num_time_steps = 50\n",


### PR DESCRIPTION
The suggested number of training iterations is not the same as the declared variable.

More precisely: **"# After around 10000-20000 training iterations the model reaches good performance on mass-spring systems with 5-8 masses."**,
while the code: `num_training_iterations = 100000`.